### PR TITLE
update all dependencies, use new ssb-meta-feeds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [16.x]
 
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "compile": "tsc",
     "test": "npm run compile && npm run tape",
-    "tape": "tape test/*.js | tap-bail | tap-spec"
+    "tape": "tape test/*.js | tap-arc --bail"
   },
   "repository": {
     "url": "https://github.com/staltz/ssb-fixtures"
@@ -28,17 +28,18 @@
     "p-defer": "^3.0.0",
     "promisify-4loc": "1.0.0",
     "rimraf": "^3.0.2",
-    "secret-stack": "^6.4.0",
+    "secret-stack": "^6.4.1",
+    "ssb-bendy-butt": "^1.0.2",
     "ssb-caps": "^1.1.0",
-    "ssb-config": "^3.4.5",
-    "ssb-db": "20.3.0",
-    "ssb-db2": "^3.0.0",
-    "ssb-friends": "^5.1.0",
-    "ssb-index-feed-writer": "~0.7.0",
-    "ssb-keys": "^8.1.0",
+    "ssb-config": "^3.4.6",
+    "ssb-db": "20.4.1",
+    "ssb-db2": "^6.3.2",
+    "ssb-friends": "^5.1.7",
+    "ssb-index-feeds": "~0.10.2",
+    "ssb-keys": "^8.5.0",
     "ssb-logging": "1.0.0",
     "ssb-master": "1.0.3",
-    "ssb-meta-feeds": "~0.26.1",
+    "ssb-meta-feeds": "~0.38.2",
     "yargs": "^17.0.1"
   },
   "devDependencies": {
@@ -46,13 +47,12 @@
     "flumecodec": "^0.0.1",
     "flumedb": "^2.1.8",
     "flumelog-offset": "^3.4.4",
-    "pull-stream": "3.6.14",
-    "ssb-ref": "2.14.3",
-    "ssb-typescript": "^2.5.0",
-    "tap-bail": "^1.0.0",
-    "tap-spec": "^5.0.0",
-    "tape": "^5.2.2",
-    "typescript": "^4.3.4"
+    "pull-stream": "3.7.0",
+    "ssb-ref": "2.16.0",
+    "ssb-typescript": "^2.8.0",
+    "tap-arc": "0.3.5",
+    "tape": "^5.6.2",
+    "typescript": "^4.9.4"
   },
   "pnpm": {
     "overrides": {

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Andre 'Staltz' Medeiros
+SPDX-FileCopyrightText: 2021-2023 Andre 'Staltz' Medeiros
 
 SPDX-License-Identifier: Unlicense

--- a/test/index-feeds.js
+++ b/test/index-feeds.js
@@ -25,8 +25,10 @@ test('generation supports simulating meta feeds and index feeds', (t) => {
       indexFeedTypes: 'about,vote,contact,post,private,other'
     },
     async (err, msgs, cleanup, outputDir) => {
-      // (seed + announce + add main + add indexes + add 6 index) * A
-      const META_MSG_COUNT = 10 * A;
+      // (seed + announce + add main + add v1 + add ~shards + add 6 index) * A
+      // Should be `11 * A`, but "~shards" means we dont know exactly how many
+      // shards there will be, so we use the hardcoded result instead.
+      const META_MSG_COUNT = 68; // 11 * A;
       // Seems like we should have only `M` index feed msgs, right?
       // But it's truly `M + A` because each author will publish a **private**
       // message `metafeed/seed` and this message will be taken into account
@@ -42,6 +44,9 @@ test('generation supports simulating meta feeds and index feeds', (t) => {
 
       const sbot = SecretStack({caps: require('ssb-caps')})
         .use(require('ssb-db2'))
+        .use(require('ssb-bendy-butt'))
+        .use(require('ssb-meta-feeds'))
+        .use(require('ssb-index-feeds'))
         .call(null, {
           path: outputDir,
           keys: ssbKeys.loadOrCreateSync(path.join(outputDir, 'secret')),


### PR DESCRIPTION
This has been long overdue, but now I've been bothered by it because I can't easily npm install anymore without getting issues involving ssb-validate2-rsjs-node and other things. The main problem is ssb-fixtures depending on an older version of ssb-db2.

Also, it's nice that ssb-fixtures is updated to the new ssb-meta-feeds (v1 structure) and the new index feeds.

----

This is a **breaking change** and will require a `release 4.0.0` commit message so that it generates the dataset in GitHub.